### PR TITLE
fix #5: use correct Tailwind classes in Tooltip

### DIFF
--- a/presets/lara/tooltip/index.js
+++ b/presets/lara/tooltip/index.js
@@ -34,9 +34,9 @@ export default {
 
             // Spacing
             {
-                '-m-t-1 ': context?.right || (!context?.right && !context?.left && !context?.top && !context?.bottom),
-                '-m-t-1': context?.left,
-                '-m-l-1': context?.top || context?.bottom
+                '-mt-1 ': context?.right || (!context?.right && !context?.left && !context?.top && !context?.bottom),
+                '-mt-1': context?.left,
+                '-ml-1': context?.top || context?.bottom
             }
         ]
     }),


### PR DESCRIPTION
This is for #5. It fixes the incorrect Tailwind classes.