### PR TITLE
Update icon only button size to match regular button

### DIFF
--- a/presets/lara/button/index.js
+++ b/presets/lara/button/index.js
@@ -13,7 +13,7 @@ export default {
                 'text-xl py-3 px-4': props.size === 'large'
             },
             {
-                'h-12 w-12 p-0': props.label == null
+                'h-10 w-10 p-0': props.label == null
             },
 
             // Shapes


### PR DESCRIPTION
While testing the buttons I noticed that the icon only button size doesn't match with the regular buttons.

<img width="1307" alt="Screenshot 2024-01-02 at 12 22 10" src="https://github.com/primefaces/primevue-tailwind/assets/5788410/800626f5-c5fe-492d-a26a-aee5515b66e8">


This PR updates the icon only button size to match to others.

<img width="929" alt="Screenshot 2024-01-02 at 12 22 20" src="https://github.com/primefaces/primevue-tailwind/assets/5788410/4347bac4-b88d-4e14-bc8e-16eeaa4454e8">
