### PR TITLE
Extend icon import doc with instructions for applications without scss

### DIFF
--- a/doc/icons/ImportDoc.vue
+++ b/doc/icons/ImportDoc.vue
@@ -1,6 +1,10 @@
 <template>
     <DocSectionText v-bind="$attrs">
-        <p>CSS file of the icon library needs to be imported in <i>styles.scss</i> of your application.</p>
+        <p>If you are using SCSS, the CSS file of the icon library needs to be imported in <i>styles.scss</i> of your application.</p>
+    </DocSectionText>
+    <DocSectionCode :code="code" hideToggleCode importCode hideCodeSandbox hideStackBlitz />
+    <DocSectionText v-bind="$attrs">
+        <p>If you are using plain css you need to import it in your <i>index.html</i> file.</p>
     </DocSectionText>
     <DocSectionCode :code="code" hideToggleCode importCode hideCodeSandbox hideStackBlitz />
 </template>
@@ -9,8 +13,11 @@
 export default {
     data() {
         return {
-            code: {
+            scssCode: {
                 basic: "\nimport 'primeicons/primeicons.css'\n"
+            },
+            cssCode: {
+                basic: '\n<link href="/node_modules/primeicons/primeicons.css" rel="stylesheet">\n'
             }
         };
     }

--- a/doc/icons/ImportDoc.vue
+++ b/doc/icons/ImportDoc.vue
@@ -2,11 +2,11 @@
     <DocSectionText v-bind="$attrs">
         <p>If you are using SCSS, the CSS file of the icon library needs to be imported in <i>styles.scss</i> of your application.</p>
     </DocSectionText>
-    <DocSectionCode :code="code" hideToggleCode importCode hideCodeSandbox hideStackBlitz />
+    <DocSectionCode :code="scssCode" hideToggleCode importCode hideCodeSandbox hideStackBlitz />
     <DocSectionText v-bind="$attrs">
         <p>If you are using plain css you need to import it in your <i>index.html</i> file.</p>
     </DocSectionText>
-    <DocSectionCode :code="code" hideToggleCode importCode hideCodeSandbox hideStackBlitz />
+    <DocSectionCode :code="cssCode" hideToggleCode importCode hideCodeSandbox hideStackBlitz />
 </template>
 
 <script>


### PR DESCRIPTION
I had to search around for a while to figure out how to add Primeicons to Vue application, that are not using SCSS. I believe adding this to the docs could save others some time.