### PR TITLE
fix: add second picker in calendar

### DIFF
--- a/presets/lara/calendar/index.js
+++ b/presets/lara/calendar/index.js
@@ -451,6 +451,17 @@ export default {
             'px-2'
         ]
     },
+    secondPicker: {
+        class: [
+            // Flexbox and Alignment
+            'flex',
+            'items-center',
+            'flex-col',
+
+            // Spacing
+            'px-2'
+        ]
+    },
     ampmpicker: {
         class: [
             // Flexbox and Alignment

--- a/presets/wind/calendar/index.js
+++ b/presets/wind/calendar/index.js
@@ -429,6 +429,17 @@ export default {
             'px-2'
         ]
     },
+    secondPicker: {
+        class: [
+            // Flexbox and Alignment
+            'flex',
+            'items-center',
+            'flex-col',
+
+            // Spacing
+            'px-2'
+        ]
+    },
     ampmpicker: {
         class: [
             // Flexbox and Alignment


### PR DESCRIPTION
After I added the `showSeconds` prop in `Calendar`, I found the seconds' section is un-styled.