### PR TITLE
Change PrimeOne to Lara for consistency

### DIFF
--- a/components/app/AppConfig.vue
+++ b/components/app/AppConfig.vue
@@ -12,7 +12,7 @@
                     }"
                     @click="setPreset('lara')"
                 >
-                    PrimeOne
+                    Lara
                 </button>
                 <button
                     type="button"

--- a/components/doc/codeeditor/templates.js
+++ b/components/doc/codeeditor/templates.js
@@ -549,7 +549,7 @@ export default {
                 }"
                 @click="setPreset('lara')"
             >
-                PrimeOne
+                Lara
             </button>
             <button
                 type="button"


### PR DESCRIPTION
In presets and labeling already using `Lara`, but the theme switcher still uses `PrimeOne`