### PR TITLE
Lara - remove duplicate tailwind class properties

### DIFF
--- a/presets/lara/dialog/index.js
+++ b/presets/lara/dialog/index.js
@@ -223,7 +223,7 @@ export default {
                   enterFromClass: 'opacity-0 scale-75 translate-x-full translate-y-0 translate-z-0 mask-active',
                   enterActiveClass: 'transition-all duration-200 ease-out',
                   leaveActiveClass: 'transition-all duration-200 ease-out',
-                  leaveToClass: 'opacity-0 scale-75 opacity-0 scale-75 translate-x-full translate-y-0 translate-z-0 mask-active'
+                  leaveToClass: 'opacity-0 scale-75 translate-x-full translate-y-0 translate-z-0 mask-active'
               }
             : {
                   enterFromClass: 'opacity-0 scale-75 mask-active',

--- a/presets/lara/fieldset/index.js
+++ b/presets/lara/fieldset/index.js
@@ -52,7 +52,7 @@ export default {
             { 'rounded-md': props.toggleable },
 
             // Color
-            { 'text-surface-700 dark:text-surface-200 hover:text-surface-900 hover:text-surface-900': props.toggleable },
+            { 'text-surface-700 dark:text-surface-200 hover:text-surface-900': props.toggleable },
 
             // States
             { 'hover:text-surface-900 dark:hover:text-surface-100': props.toggleable },


### PR DESCRIPTION
Minor:   

In the Lara presets, a couple of files have duplicate TailwindCSS properties

- Dialog
- Fieldset