### PR TITLE
fix: Lara - "focus:z-10" apply to both InputText/InputNumber

### DIFF
--- a/presets/lara/inputnumber/index.js
+++ b/presets/lara/inputnumber/index.js
@@ -48,7 +48,7 @@ export default {
 
                 // States
                 'hover:border-primary-500 dark:hover:border-primary-400',
-                'focus:outline-none focus:outline-offset-0 focus:ring focus:ring-primary-500/50 dark:focus:ring-primary-400/50',
+                'focus:outline-none focus:outline-offset-0 focus:ring focus:ring-primary-500/50 dark:focus:ring-primary-400/50 focus:z-10',
                 { 'opacity-60 select-none pointer-events-none cursor-default': context.disabled },
 
                 //Position

--- a/presets/lara/inputtext/index.js
+++ b/presets/lara/inputtext/index.js
@@ -27,7 +27,7 @@ export default {
             // States
             {
                 'hover:border-primary-500 dark:hover:border-primary-400': !context.disabled,
-                'focus:outline-none focus:outline-offset-0 focus:ring focus:ring-primary-500/50 dark:focus:ring-primary-400/50': !context.disabled,
+                'focus:outline-none focus:outline-offset-0 focus:ring focus:ring-primary-500/50 dark:focus:ring-primary-400/50 focus:z-10': !context.disabled,
                 'opacity-60 select-none pointer-events-none cursor-default': context.disabled
             },
 


### PR DESCRIPTION
Similar to #94 - these two components need the same z-index treatment

Seen in combo with InputGroup and when a component positioned on the right side.

ex: InputText from site:

![image](https://github.com/primefaces/primevue-tailwind/assets/41694/4a29a95a-323f-4c3b-b27e-121bac8c0b87)
