### PR TITLE
Lara - fix InputNumber focus outline

### DIFF
--- a/presets/lara/inputnumber/index.js
+++ b/presets/lara/inputnumber/index.js
@@ -48,7 +48,7 @@ export default {
 
                 // States
                 'hover:border-primary-500 dark:hover:border-primary-400',
-                'focus:outline-none focus:outline-offset-0 focus:ring focus:ring-primary-500/50 dark:focus:ring-primary-400/50',
+                'focus:outline-none focus:outline-offset-0 focus:ring focus:ring-primary-500/50 dark:focus:ring-primary-400/50 focus:z-10',
                 { 'opacity-60 select-none pointer-events-none cursor-default': context.disabled },
 
                 //Position


### PR DESCRIPTION
On button focus the outline is not fully visible
![image](https://github.com/primefaces/primevue-tailwind/assets/33941527/f1a0bad6-66db-4d1c-92bf-b41a845a71f6)

I added z-10 to input on focus which fixed the problem
![image](https://github.com/primefaces/primevue-tailwind/assets/33941527/4f8751b4-e5c4-47ff-a6b4-8be371a1dadd)

I'm not sure about other inputs, I'll try to notify you when I find something else.