### PR TITLE
modifies the alignment in the input group components

### DIFF
--- a/doc/inputgroup/BasicDoc.vue
+++ b/doc/inputgroup/BasicDoc.vue
@@ -2,7 +2,7 @@
     <DocSectionText v-bind="$attrs">
         <p>A group is created by wrapping the input and add-ons with the <i>InputGroup</i> component. Each add-on element is defined as a child of <i>InputGroupAddon</i> component.</p>
     </DocSectionText>
-    <div class="card flex flex-col md:flex-row gap-3">
+    <div class="card flex flex-col gap-3">
         <InputGroup>
             <InputGroupAddon>
                 <i class="pi pi-user"></i>

--- a/doc/inputgroup/ButtonDoc.vue
+++ b/doc/inputgroup/ButtonDoc.vue
@@ -2,7 +2,7 @@
     <DocSectionText v-bind="$attrs">
         <p>Buttons can be placed at either side of an input element.</p>
     </DocSectionText>
-    <div class="card flex flex-col md:flex-row gap-3">
+    <div class="card flex flex-col gap-3">
         <InputGroup>
             <Button label="Search" />
             <InputText placeholder="Keyword" />

--- a/doc/inputgroup/CheckboxDoc.vue
+++ b/doc/inputgroup/CheckboxDoc.vue
@@ -2,7 +2,7 @@
     <DocSectionText v-bind="$attrs">
         <p>Checkbox and RadioButton components can be combined with an input element under the same group.</p>
     </DocSectionText>
-    <div class="card flex flex-col md:flex-row gap-3">
+    <div class="card flex flex-col gap-3">
         <InputGroup>
             <InputText placeholder="Price" />
             <InputGroupAddon>


### PR DESCRIPTION
### fix input group documentation styles
![image](https://github.com/primefaces/primevue-tailwind/assets/78767630/00b9d691-421f-4658-bc27-9667dd862e4c)
![image](https://github.com/primefaces/primevue-tailwind/assets/78767630/896c2175-ea41-4585-83ed-868e02a20b7c)
![image](https://github.com/primefaces/primevue-tailwind/assets/78767630/b0477e10-fbb9-4ed1-b034-20ac366bb44c)

### correction

![image](https://github.com/primefaces/primevue-tailwind/assets/78767630/1de08198-2011-4655-9705-aad2a0f38382)
![image](https://github.com/primefaces/primevue-tailwind/assets/78767630/ab50294e-6108-4f78-8849-d7a644f8de01)
![image](https://github.com/primefaces/primevue-tailwind/assets/78767630/3cebe464-fbc5-4c32-b4b5-a99068b4b17f)

