### PR TITLE
Adjust dropdown styles, when used in input groups for the two presets: lara and wind

### DIFF
--- a/presets/lara/dropdown/index.js
+++ b/presets/lara/dropdown/index.js
@@ -6,11 +6,17 @@ export default {
             'relative',
 
             // Shape
-            'rounded-md',
+            { 'rounded-md': parent.instance.$name !== 'InputGroup' },
+            { 'first:rounded-l-md rounded-none last:rounded-r-md': parent.instance.$name == 'InputGroup' },
+            { 'border-0 border-y border-l last:border-r': parent.instance.$name == 'InputGroup' },
+            { 'first:ml-0 ml-[-1px]': parent.instance.$name == 'InputGroup' && !props.showButtons },
 
             // Color and Background
             'bg-surface-0 dark:bg-surface-900',
-            'border border-surface-300 dark:border-surface-700',
+            'border border-surface-300',
+            {'dark:border-surface-700': parent.instance.$name != 'InputGroup'},
+            {'dark:border-surface-600': parent.instance.$name == 'InputGroup'},
+                
 
             // Transitions
             'transition-all',

--- a/presets/wind/dropdown/index.js
+++ b/presets/wind/dropdown/index.js
@@ -1,5 +1,5 @@
 export default {
-    root: ({ props, state }) => ({
+    root: ({ props, state, parent }) => ({
         class: [
             // Display and Position
             'inline-flex',

--- a/presets/wind/dropdown/index.js
+++ b/presets/wind/dropdown/index.js
@@ -5,15 +5,21 @@ export default {
             'inline-flex',
             'relative',
 
+            // Flex
+            { 'flex-1 w-[1%]': parent.instance.$name == 'InputGroup' },
+
             // Shape
-            'rounded-md',
             'shadow-sm',
+            { 'rounded-md': parent.instance.$name !== 'InputGroup' },
+            { 'first:rounded-l-md rounded-none last:rounded-r-md': parent.instance.$name == 'InputGroup' },
+            { 'border-0 border-y border-l last:border-r border-surface-300 dark:border-surface-600': parent.instance.$name == 'InputGroup' },
+            { 'first:ml-0 ml-[-1px]': parent.instance.$name == 'InputGroup' && !props.showButtons },
 
             // Color and Background
             'bg-surface-0 dark:bg-surface-900',
 
             // States
-            { 'ring-1 ring-inset ring-surface-300 dark:ring-surface-700': !state.focused, 'ring-2 ring-inset ring-primary-500 dark:ring-primary-400': state.focused },
+            { 'ring-1 ring-inset ring-surface-300 dark:ring-surface-700': parent.instance.$name !== 'InputGroup' && !state.focused, 'ring-2 ring-inset ring-primary-500 dark:ring-primary-400': parent.instance.$name !== 'InputGroup' && state.focused },
 
             // Misc
             'cursor-default',


### PR DESCRIPTION
I just used the styles, which are applied to the "InputText" component and adjusted them for the "Dropdown" component, when it is used inside of an input group.
I tested it locally 