### PR TITLE
fix(contextmenu): add missing disabled styles

### DIFF
--- a/doc/contextmenu/BasicDoc.vue
+++ b/doc/contextmenu/BasicDoc.vue
@@ -15,7 +15,8 @@ export default {
         return {
             items: [
                 { label: 'Copy', icon: 'pi pi-copy' },
-                { label: 'Rename', icon: 'pi pi-file-edit' }
+                { label: 'Rename', icon: 'pi pi-file-edit' },
+                { label: 'Delete', icon: 'pi pi-trash', disabled: true },
             ],
             code: {
                 basic: `
@@ -36,7 +37,8 @@ export default {
         return {
             items: [
                 { label: 'Copy', icon: 'pi pi-copy' },
-                { label: 'Rename', icon: 'pi pi-file-edit' }
+                { label: 'Rename', icon: 'pi pi-file-edit' },
+                { label: 'Delete', icon: 'pi pi-trash', disabled: true },
             ]
         };
     },
@@ -62,7 +64,8 @@ import { ref } from 'vue';
 const menu = ref();
 const items = ref([
     { label: 'Copy', icon: 'pi pi-copy' },
-    { label: 'Rename', icon: 'pi pi-file-edit' }
+    { label: 'Rename', icon: 'pi pi-file-edit' },
+    { label: 'Delete', icon: 'pi pi-trash', disabled: true },
 ]);
 
 const onImageRightClick = (event) => {

--- a/presets/lara/contextmenu/index.js
+++ b/presets/lara/contextmenu/index.js
@@ -48,7 +48,10 @@ export default {
             {
                 'hover:bg-surface-100 dark:hover:bg-surface-600/80': !context.active,
                 'hover:bg-primary-400/30 dark:hover:bg-primary-300/30 text-primary-700 dark:text-surface-0/80': context.active
-            }
+            },
+
+            // Disabled
+            { 'opacity-60 pointer-events-none cursor-default': context.disabled }
         ]
     }),
     action: {

--- a/presets/wind/contextmenu/index.js
+++ b/presets/wind/contextmenu/index.js
@@ -48,7 +48,10 @@ export default {
 
             // Transitions
             'transition-shadow',
-            'duration-200'
+            'duration-200',
+
+            // Disabled
+            { 'opacity-60 pointer-events-none cursor-default': context.disabled }
         ]
     }),
     action: {


### PR DESCRIPTION
Hey there 👋 

I've realized the styles were missing for disabled contextmenu items, so I've added them in this PR. I've also added an example in the docs.

Lara:
![image](https://github.com/primefaces/primevue-tailwind/assets/31937175/6b89feab-ad4b-47c1-803c-ddac72abbaf8)


Wind:
![image](https://github.com/primefaces/primevue-tailwind/assets/31937175/01bc2702-e800-4eac-b5c0-e44a481d28aa)
