### PR TITLE
chore: update nuxt to v3.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     },
     "dependencies": {
         "@docsearch/js": "^3.3.3",
-        "nuxt": "3.3.2",
+        "nuxt": "~3.8.2",
         "nuxt-gtag": "^0.6.2",
         "nuxt-primevue": "^0.3.0",
         "primeicons": "^6.0.1",


### PR DESCRIPTION
Version 3.3.2 came out [almost a year ago](https://github.com/nuxt/nuxt/releases/tag/v3.3.2). I've updated it to v3.8.2, which is more recent and very stable in my experience. 

I've skimmed through the docs, and haven't found any issues caused by the update.