### PR TITLE
refactor: use px utilities from the default tailwind config

### DIFF
--- a/presets/lara/inputnumber/index.js
+++ b/presets/lara/inputnumber/index.js
@@ -9,7 +9,7 @@ export default {
             // Shape
             { 'first:rounded-l-md rounded-none last:rounded-r-md': parent.instance.$name == 'InputGroup' && !props.showButtons },
             { 'border-0 border-y border-l last:border-r border-surface-300 dark:border-surface-600': parent.instance.$name == 'InputGroup' && !props.showButtons },
-            { 'first:ml-0 ml-[-1px]': parent.instance.$name == 'InputGroup' && !props.showButtons },
+            { 'first:ml-0 -ml-px': parent.instance.$name == 'InputGroup' && !props.showButtons },
 
             //Sizing
             { '!w-16': props.showButtons && props.buttonLayout == 'vertical' }

--- a/presets/lara/inputtext/index.js
+++ b/presets/lara/inputtext/index.js
@@ -19,7 +19,7 @@ export default {
             { 'rounded-md': parent.instance.$name !== 'InputGroup' },
             { 'first:rounded-l-md rounded-none last:rounded-r-md': parent.instance.$name == 'InputGroup' },
             { 'border-0 border-y border-l last:border-r': parent.instance.$name == 'InputGroup' },
-            { 'first:ml-0 ml-[-1px]': parent.instance.$name == 'InputGroup' && !props.showButtons },
+            { 'first:ml-0 -ml-px': parent.instance.$name == 'InputGroup' && !props.showButtons },
 
             // Colors
             'text-surface-600 dark:text-surface-200',

--- a/presets/lara/password/index.js
+++ b/presets/lara/password/index.js
@@ -82,7 +82,7 @@ export default {
                 { 'rounded-md': parent.instance.$name !== 'InputGroup' },
                 { 'first:rounded-l-md rounded-none last:rounded-r-md': parent.instance.$name == 'InputGroup' },
                 { 'border-0 border-y border-l last:border-r': parent.instance.$name == 'InputGroup' },
-                { 'first:ml-0 ml-[-1px]': parent.instance.$name == 'InputGroup' && !props.showButtons },
+                { 'first:ml-0 -ml-px': parent.instance.$name == 'InputGroup' && !props.showButtons },
 
                 // Colors
                 'text-surface-600 dark:text-surface-200',

--- a/presets/wind/autocomplete/index.js
+++ b/presets/wind/autocomplete/index.js
@@ -139,7 +139,7 @@ export default {
 
                 // Size
                 'px-2.5 py-1.5',
-                '-ml-[1px]',
+                '-ml-px',
 
                 // Colors
                 'text-surface-600 dark:text-surface-100',

--- a/presets/wind/calendar/index.js
+++ b/presets/wind/calendar/index.js
@@ -27,7 +27,7 @@ export default {
 
             // Spacing
             'm-0 py-1.5 px-3',
-            '-ml-[1px]',
+            '-ml-px',
 
             // Shape
             'appearance-none',

--- a/presets/wind/inputtext/index.js
+++ b/presets/wind/inputtext/index.js
@@ -26,7 +26,7 @@ export default {
             { 'rounded-md': parent.instance.$name !== 'InputGroup' },
             { 'first:rounded-l-md rounded-none last:rounded-r-md': parent.instance.$name == 'InputGroup' },
             { 'border-0 border-y border-l last:border-r border-surface-300 dark:border-surface-600': parent.instance.$name == 'InputGroup' },
-            { 'first:ml-0 ml-[-1px]': parent.instance.$name == 'InputGroup' && !props.showButtons },
+            { 'first:ml-0 -ml-px': parent.instance.$name == 'InputGroup' && !props.showButtons },
             'appearance-none',
 
             // Interactions

--- a/presets/wind/paginator/index.js
+++ b/presets/wind/paginator/index.js
@@ -17,7 +17,7 @@ export default {
         ]
     },
     paginatorwrapper: {
-        class: 'mt-[-1px]'
+        class: '-mt-px'
     },
     firstpagebutton: ({ context }) => ({
         class: [
@@ -33,7 +33,7 @@ export default {
             'border-t-2 border-transparent',
 
             // Size
-            'min-w-[3rem] h-12 mt-[-1px]',
+            'min-w-[3rem] h-12 -mt-px',
 
             // Color
             'text-surface-500 dark:text-white/60',
@@ -66,7 +66,7 @@ export default {
             'border-t-2 border-transparent',
 
             // Size
-            'min-w-[3rem] h-12 mt-[-1px]',
+            'min-w-[3rem] h-12 -mt-px',
 
             // Color
             'text-surface-500 dark:text-white/60',
@@ -99,7 +99,7 @@ export default {
             'border-t-2 border-transparent',
 
             // Size
-            'min-w-[3rem] h-12 mt-[-1px]',
+            'min-w-[3rem] h-12 -mt-px',
 
             // Color
             'text-surface-500 dark:text-white/60',
@@ -132,7 +132,7 @@ export default {
             'border-t-2 border-transparent',
 
             // Size
-            'min-w-[3rem] h-12 mt-[-1px]',
+            'min-w-[3rem] h-12 -mt-px',
 
             // Color
             'text-surface-500 dark:text-white/60',
@@ -165,7 +165,7 @@ export default {
             'border-t-2',
 
             // Size
-            'min-w-[3rem] h-12 mt-[-1px]',
+            'min-w-[3rem] h-12 -mt-px',
 
             // Color
             {

--- a/presets/wind/password/index.js
+++ b/presets/wind/password/index.js
@@ -90,7 +90,7 @@ export default {
                 { 'rounded-md': parent.instance.$name !== 'InputGroup' },
                 { 'first:rounded-l-md rounded-none last:rounded-r-md': parent.instance.$name == 'InputGroup' },
                 { 'border-0 border-y border-l last:border-r border-surface-300 dark:border-surface-600': parent.instance.$name == 'InputGroup' },
-                { 'first:ml-0 ml-[-1px]': parent.instance.$name == 'InputGroup' && !props.showButtons },
+                { 'first:ml-0 -ml-px': parent.instance.$name == 'InputGroup' && !props.showButtons },
                 'appearance-none',
 
                 // Interactions

--- a/presets/wind/splitbutton/index.js
+++ b/presets/wind/splitbutton/index.js
@@ -215,7 +215,7 @@ export default {
                 {
                     'min-w-8 p-0 py-1.5': parent.props.label == null && parent.props.icon !== null
                 },
-                'ml-[1px]',
+                'ml-px',
 
                 // Shape
                 'rounded-l-none',

--- a/presets/wind/tabmenu/index.js
+++ b/presets/wind/tabmenu/index.js
@@ -33,7 +33,7 @@ export default {
 
             // Spacing
             'py-4 px-3',
-            '-mb-[1px]',
+            '-mb-px',
 
             // Shape
             'border-b-2',

--- a/presets/wind/tabview/index.js
+++ b/presets/wind/tabview/index.js
@@ -97,7 +97,7 @@ export default {
 
                 // Spacing
                 'py-4 px-3',
-                '-mb-[1px]',
+                '-mb-px',
 
                 // Shape
                 'border-b-2',


### PR DESCRIPTION
Since `px` is a valid spacing value in the [default tailwind config](https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/config.full.js#L842), it is not necessary to use value interpolation to get 1px for padding, margin, etc.