### PR TITLE
added missing overflow-hidden to avatar preset for circle shape

### DIFF
--- a/presets/lara/avatar/index.js
+++ b/presets/lara/avatar/index.js
@@ -22,7 +22,7 @@ export default {
             // Shapes
             {
                 'rounded-lg': props.shape == 'square',
-                'rounded-full': props.shape == 'circle'
+                'rounded-full overflow-hidden': props.shape == 'circle'
             },
             { 'border-2': parent.instance.$style?.name == 'avatargroup' },
 

--- a/presets/wind/avatar/index.js
+++ b/presets/wind/avatar/index.js
@@ -24,7 +24,7 @@ export default {
             // Shapes
             {
                 'rounded-lg': props.shape == 'square',
-                'rounded-full': props.shape == 'circle'
+                'rounded-full overflow-hidden': props.shape == 'circle'
             },
             { 'border-2': parent.instance.$style?.name == 'avatargroup' },
 


### PR DESCRIPTION
Avatar circle shape preset is missing "overflow-hidden" class, you guys are using a circular pic for example , so the error is not visible
![image](https://github.com/primefaces/primevue-tailwind/assets/3751322/0216fcdb-4047-4f33-8ab0-1e6e903438ab)
