### PR TITLE
fix(avatar): add missing classes related to the shape prop for the image

### DIFF
--- a/presets/lara/avatar/index.js
+++ b/presets/lara/avatar/index.js
@@ -31,7 +31,13 @@ export default {
             { 'border-white dark:border-surface-800': parent.instance.$style?.name == 'avatargroup' }
         ]
     }),
-    image: {
-        class: 'h-full w-full'
-    }
+    image: ({ props }) => ({
+        class: [
+            'h-full w-full',
+            {
+                'rounded-lg': props.shape == 'square',
+                'rounded-full': props.shape == 'circle'
+            }
+        ]
+    })
 };

--- a/presets/wind/avatar/index.js
+++ b/presets/wind/avatar/index.js
@@ -33,7 +33,13 @@ export default {
             { 'border-white dark:border-surface-800': parent.instance.$style?.name == 'avatargroup' }
         ]
     }),
-    image: {
-        class: 'h-full w-full'
-    }
+    image: ({ props }) => ({
+        class: [
+            'h-full w-full',
+            {
+                'rounded-lg': props.shape == 'square',
+                'rounded-full': props.shape == 'circle'
+            }
+        ]
+    })
 };


### PR DESCRIPTION
I have found and fixed what I believe to be an issue with the "Avatar" component on both presets that has been bothering me for a while.

The image from the component doesn't update with the "shape" prop like the root container does:

### Broken Avatar Image
![incorrect-avatar](https://github.com/primefaces/primevue-tailwind/assets/43423924/0281d19d-3625-4771-802f-b29749624a66)

### Fixed Avatar Image
![correct-avatar](https://github.com/primefaces/primevue-tailwind/assets/43423924/2a9d3127-0817-4820-9fb1-5edc3ed527a2)

### Code
`<Avatar
      image="avatar.png"
      size="xlarge"
      shape="circle"
      :pt="{root: 'p2 bg-red-200!'}"
      :pt-options="{ mergeProps: true }"
    />` *
    
   \* Obs.: Padding and red background added to the root element, as an example, to exaggerate the discrepancy with the image.

It seems that the images used in the docs are, conveniently enough, rounded PNGs with transparent backgrounds, hiding this issue. Unless it's by design, but that doesn't seem likely when comparing this behavior with the "Lara" theme in styled-mode, using vanilla CSS.

This is my first time contributing, so, let me know if I this will help and if I should make any changes to adhere to the project's guidelines.

And feel free to add me as a contributor if this ends up helping in any way. This project seems so promising and the community so engaging that I'll be more than happy to contribute with fixes or suggestions as I use it in my projects. 