### PR TITLE
fix toast styling when summary prop is not added

### DIFF
--- a/presets/lara/toast/index.js
+++ b/presets/lara/toast/index.js
@@ -35,9 +35,15 @@ export default {
             }
         ]
     }),
-    content: {
-        class: 'flex items-start p-4'
-    },
+    content: ({ props }) => ({
+        class: [
+          'flex p-4',
+          {
+            'items-start': props.message.summary,
+            'items-center': !props.message.summary,
+          },
+        ],
+    }),
     icon: {
         class: [
             // Sizing and Spacing
@@ -56,9 +62,9 @@ export default {
     summary: {
         class: 'font-bold block'
     },
-    detail: {
-        class: 'mt-2 block'
-    },
+    detail: ({ props }) => ({
+        class: ['block', { 'mt-2': props.message.summary }],
+    }),
     closebutton: {
         class: [
             // Flexbox

--- a/presets/wind/toast/index.js
+++ b/presets/wind/toast/index.js
@@ -24,9 +24,15 @@ export default {
             }
         ]
     }),
-    content: {
-        class: 'flex items-start p-4'
-    },
+    content: ({ props }) => ({
+        class: [
+          'flex p-4',
+          {
+            'items-start': props.message.summary,
+            'items-center': !props.message.summary,
+          },
+        ],
+    }),
     icon: {
         class: [
             // Sizing and Spacing
@@ -45,9 +51,13 @@ export default {
     summary: {
         class: 'font-medium block'
     },
-    detail: {
-        class: 'mt-1.5 block text-surface-600 dark:text-surface-0/70'
-    },
+    detail: ({ props }) => ({
+        class: [
+          'block',
+          'text-surface-600 dark:text-surface-0/70',
+          { 'mt-1.5': props.message.summary },
+        ],
+    }),
     closebutton: {
         class: [
             // Flexbox


### PR DESCRIPTION
Hi

If we use the `toast` component without the summary field. The styles are not correct

<img width="688" alt="image" src="https://github.com/primefaces/primevue-tailwind/assets/872762/7159ab29-694a-4c4d-8ecc-5348aa0d13a6">

Updated presets (Lara, Wind) to show it correctly. Centered the content vertically if the summary is not there and removed margin-top from the detail.

<img width="612" alt="image" src="https://github.com/primefaces/primevue-tailwind/assets/872762/f3cfdc01-9ca4-42e0-8143-787eb5edd7aa">

Fix demo: https://stackblitz.com/edit/icxzv3?file=src%2FApp.vue,src%2Fpresets%2Fwind%2Ftoast%2Findex.js,src%2Fpresets%2Flara%2Ftoast%2Findex.js,src%2Fmain.js
