### PR TITLE
Add border to invalid input

### DIFF
--- a/presets/lara/inputtext/index.js
+++ b/presets/lara/inputtext/index.js
@@ -29,6 +29,8 @@ export default {
             { 'border-surface-300 dark:border-surface-600': !props.invalid },
 
             // Invalid State
+            'invalid:focus:ring-red-200',
+            'invalid:hover:border-red-500',
             { 'border-red-500 dark:border-red-400': props.invalid },
 
             // States


### PR DESCRIPTION
The `InputText.vue` component doesn't change the color of its border when the input value is not following the rules of the required type.

Then, I added `invalid:focus:ring-red-200` and `invalid:hover:border-red-500` classes to InputText in lara preset.