### PR TITLE
fix overflow in FileInput file's name

### DIFF
--- a/presets/lara/fileupload/index.js
+++ b/presets/lara/fileupload/index.js
@@ -125,7 +125,7 @@ export default {
         class: 'shrink-0'
     },
     fileName: {
-        class: 'mb-2'
+        class: 'mb-2 break-all'
     },
     fileSize: {
         class: 'mr-2'


### PR DESCRIPTION
on small screens, when the file name was too long, it would overflow instead of break into next line

before:
![image](https://github.com/primefaces/primevue-tailwind/assets/33941527/ef18568a-314a-4fcb-ab97-c1df629d7291)

after:
![image](https://github.com/primefaces/primevue-tailwind/assets/33941527/656e8e27-1a9c-44cc-ab19-59ca4c3ad92d)
