### PR TITLE
fix timeline last content preset not applying

### DIFF
--- a/presets/lara/timeline/index.js
+++ b/presets/lara/timeline/index.js
@@ -73,8 +73,8 @@ export default {
                 'text-right': props.align === 'right' || (props.layout === 'vertical' && props.align === 'alternate' && context.index % 2 === 1)
             },
             {
-                'min-h-0': props.layout === 'vertical' && context.index === context.count,
-                'grow-0': props.layout === 'horizontal' && context.index === context.count
+                'min-h-0': props.layout === 'vertical' && context.index === context.count - 1,
+                'grow-0': props.layout === 'horizontal' && context.index === context.count - 1
             }
         ]
     })

--- a/presets/wind/timeline/index.js
+++ b/presets/wind/timeline/index.js
@@ -73,8 +73,8 @@ export default {
                 'text-right': props.align === 'right' || (props.layout === 'vertical' && props.align === 'alternate' && context.index % 2 === 1)
             },
             {
-                'min-h-0': props.layout === 'vertical' && context.index === context.count,
-                'grow-0': props.layout === 'horizontal' && context.index === context.count
+                'min-h-0': props.layout === 'vertical' && context.index === context.count - 1,
+                'grow-0': props.layout === 'horizontal' && context.index === context.count - 1
             }
         ]
     })


### PR DESCRIPTION
`context.index === context.count` always return false cause `context.index` start from 0