### PR TITLE
fix z-index in datatable when column is frozen

### DIFF
--- a/presets/lara/datatable/index.js
+++ b/presets/lara/datatable/index.js
@@ -146,7 +146,7 @@ export default {
             class: [
                 //Position
                 { 'sticky box-border border-b': parent.instance.frozenRow },
-                { 'sticky box-border border-b': props.frozen || props.frozen === '' },
+                { 'sticky box-border border-b z-20': props.frozen || props.frozen === '' },
 
                 // Alignment
                 'text-left',

--- a/presets/lara/datatable/index.js
+++ b/presets/lara/datatable/index.js
@@ -63,7 +63,7 @@ export default {
     thead: ({ context }) => ({
         class: [
             {
-                'bg-surface-50 top-0 z-40 sticky': context.scrollable
+                'bg-surface-50 dark:bg-surface-800 top-0 z-40 sticky': context.scrollable
             }
         ]
     }),


### PR DESCRIPTION
When you add, for example, a button to datatable column, then freeze column, the column would display under the column. 
before:
<img width="290" alt="image" src="https://github.com/primefaces/primevue-tailwind/assets/33941527/d94e68c4-1b51-41ae-9c8e-ea1bb6ae86a0">

after:
<img width="206" alt="image" src="https://github.com/primefaces/primevue-tailwind/assets/33941527/4c42dfc2-b909-4201-8a41-06df198a56b5">

Frozen rows might need this fix too.