### PR TITLE
fix datatable with scrollable attribute breaks the sortable header style

### DIFF
--- a/presets/lara/datatable/index.js
+++ b/presets/lara/datatable/index.js
@@ -63,7 +63,7 @@ export default {
     thead: ({ context }) => ({
         class: [
             {
-                'bg-surface-50 top-0 z-40 sticky': context.scrollable
+                'bg-surface-50 dark:bg-surface-800 top-0 z-40 sticky': context.scrollable
             }
         ]
     }),


### PR DESCRIPTION
in dark mode, when you use scrollable attribute on datatable and sort column, the style of the header seems to be broken

before:
![image](https://github.com/primefaces/primevue-tailwind/assets/33941527/ae4dbcba-c5ca-4dc7-970f-ba5ba51e29af)

after:
![image](https://github.com/primefaces/primevue-tailwind/assets/33941527/49b303c0-c86f-4539-9dfd-80a44fcb6d8e)
