### PR TITLE
add default background to table body in datatable

### DIFF
--- a/presets/lara/datatable/index.js
+++ b/presets/lara/datatable/index.js
@@ -71,7 +71,8 @@ export default {
         class: [
             {
                 'sticky z-20': instance.frozenRow && context.scrollable
-            }
+            },
+            'bg-surface-50 dark:bg-surface-800'
         ]
     }),
     tfoot: ({ context }) => ({


### PR DESCRIPTION
Empty table look odd with the other default components/dragging and dropping rows (when the background is visible). I added default background to table body.

before:
<img width="479" alt="image" src="https://github.com/primefaces/primevue-tailwind/assets/33941527/e9449ed9-f01a-460b-8147-8abd817abc29">

after:
<img width="298" alt="image" src="https://github.com/primefaces/primevue-tailwind/assets/33941527/28c8b714-e4c5-4f26-a509-f9055d54cc2c">
