### PR TITLE
Menubar - Presets missing disabled styles

### DIFF
--- a/presets/lara/menubar/index.js
+++ b/presets/lara/menubar/index.js
@@ -73,6 +73,9 @@ export default {
                 'hover:bg-primary-500/50 dark:hover:bg-primary-300/30 text-primary-700 dark:text-surface-0/80': context.active
             },
 
+            // Disabled State
+            { 'opacity-60 pointer-events-none cursor-default': context.disabled },
+
             // Transitions
             'transition-all',
             'duration-200'

--- a/presets/wind/menubar/index.js
+++ b/presets/wind/menubar/index.js
@@ -77,6 +77,9 @@ export default {
                 'hover:bg-surface-100 dark:hover:bg-black/40 text-surface-900 dark:text-surface-0/80': context.active
             },
 
+            // Disabled State
+            { 'opacity-60 pointer-events-none cursor-default': context.disabled },
+
             // Transitions
             'transition-all',
             'duration-200'


### PR DESCRIPTION
Both Lara and Wind are missing disabled styles:

```
// Disabled state
{ 'opacity-60 pointer-events-none cursor-default': context.disabled }
```

Without the fix, adding the `disabled` option to an item and setting it to `true` does nothing. 