### PR TITLE
Adjust image preview button size

### DIFF
--- a/presets/lara/image/index.js
+++ b/presets/lara/image/index.js
@@ -11,7 +11,7 @@ export default {
             'absolute',
 
             // Shape
-            'inset-0 opacity-0 transition-opacity duration-300',
+            'inset-0 opacity-0 transition-opacity duration-300 w-full h-full',
 
             // Color
             'bg-transparent text-surface-100',

--- a/presets/wind/image/index.js
+++ b/presets/wind/image/index.js
@@ -11,7 +11,7 @@ export default {
             'absolute',
 
             // Shape
-            'inset-0 opacity-0 transition-opacity duration-300',
+            'inset-0 opacity-0 transition-opacity duration-300 w-full h-full',
 
             // Color
             'bg-transparent text-surface-100',


### PR DESCRIPTION
First, thanks for your awesome work!
This is a small tweak to fix the image preview button bug I noticed on Firefox.
Chrome automatically renders the button covering the image based (I guess) on inset-0, but Firefox needed the width and height set.

Problem:

![image](https://github.com/primefaces/primevue-tailwind/assets/21963503/cbf6f4a7-87a6-400f-8a7b-a9633a791445)
