### PR TITLE
fix: button icon without text size

### DIFF
--- a/presets/lara/button/index.js
+++ b/presets/lara/button/index.js
@@ -14,7 +14,7 @@ export default {
                 'text-xl py-3 px-4': props.size === 'large'
             },
             {
-                'w-12 p-0 py-3': props.label == null && props.icon !== null
+                'w-12 p-0 py-3': props.label == null && props.icon !== null && props.size !== 'small'
             },
 
             // Shapes

--- a/presets/wind/button/index.js
+++ b/presets/wind/button/index.js
@@ -14,7 +14,7 @@ export default {
                 'px-3 py-2': props.size === 'large'
             },
             {
-                'h-8 w-8 p-0': props.label == null && props.icon !== null
+                'h-8 w-8 p-0': props.label == null && props.icon !== null && props.size !== 'small'
             },
 
             // Shapes


### PR DESCRIPTION
Hi, 

I encountered a button size problem when I use it without text and with an icon only

Example with icon size small: 
<img width="211" alt="image" src="https://github.com/primefaces/primevue-tailwind/assets/93582464/d5a29be5-50fe-4119-93d3-7d35a2805604">


After changes:
<img width="204" alt="image" src="https://github.com/primefaces/primevue-tailwind/assets/93582464/bee9e0c5-47f1-4fdc-8e15-e35ae9e7e7db">
