### PR TITLE
fix: Dropdown loading icon is not spinning

### DIFF
--- a/presets/lara/dropdown/index.js
+++ b/presets/lara/dropdown/index.js
@@ -262,6 +262,9 @@ export default {
             '-mt-2'
         ]
     },
+    loadingicon: {
+        class: 'w-5 h-5 animate-spin'
+    },
     transition: {
         enterFromClass: 'opacity-0 scale-y-[0.8]',
         enterActiveClass: 'transition-[transform,opacity] duration-[120ms] ease-[cubic-bezier(0,0,0.2,1)]',

--- a/presets/wind/dropdown/index.js
+++ b/presets/wind/dropdown/index.js
@@ -260,6 +260,9 @@ export default {
             '-mt-2'
         ]
     },
+    loadingicon: {
+        class: 'w-4 h-4 animate-spin'
+    },
     transition: {
         enterFromClass: 'opacity-0 scale-y-[0.8]',
         enterActiveClass: 'transition-[transform,opacity] duration-[120ms] ease-[cubic-bezier(0,0,0.2,1)]',


### PR DESCRIPTION
This pull request fixes the dropdown icon not spinning when the loading state is set to true.

Related to #223 