### PR TITLE
Platform agnostic reference to `lara` import

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -2,6 +2,8 @@ import path from 'path';
 
 const baseUrl = '/';
 
+let lara = process.platform === 'win32' ? { as: 'Lara', from: '~/presets/lara' } : { from: path.resolve(__dirname, './presets/lara/') };
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
     typescript: false,
@@ -32,7 +34,7 @@ export default defineNuxtConfig({
             ripple: true,
             unstyled: true
         },
-        importPT: { from: path.resolve(__dirname, './presets/lara/') }
+        importPT: lara
     },
     app: {
         baseURL: baseUrl,


### PR DESCRIPTION
Based on feedback to the following issue:
https://github.com/primefaces/primevue-tailwind/issues/235

Add the ability to have importPT of `lara` preset as platform agnostic