### PR TITLE
[aura preset] Add w-full for password component

### DIFF
--- a/presets/aura/password/index.js
+++ b/presets/aura/password/index.js
@@ -73,7 +73,8 @@ export default {
                     'py-1.5 px-2': props.size == 'small',
                     'py-2 px-3': props.size == null
                 },
-
+                'w-full',
+                
                 // Shape
                 { 'rounded-md': parent.instance.$name !== 'InputGroup' },
                 { 'first:rounded-l-md rounded-none last:rounded-r-md': parent.instance.$name == 'InputGroup' },


### PR DESCRIPTION
Without this class, icons are displayed "out" of the component itself, if we set the password component class to `w-full`.

Example :

![image](https://github.com/primefaces/primevue-tailwind/assets/2027964/d71b7777-dd1d-47ea-b8b8-3aa409462a47)

With the `w-full` class : 

![image](https://github.com/primefaces/primevue-tailwind/assets/2027964/ae0e3be1-15b8-4e3a-9fff-6d2a3e452a54)
