### PR TITLE
Fix FloatLabel z-index

### DIFF
--- a/presets/aura/floatlabel/index.js
+++ b/presets/aura/floatlabel/index.js
@@ -17,10 +17,12 @@ export default {
             // Focus Label Appearance
             '[&>*:last-child]:has-[:focus]:-top-3',
             '[&>*:last-child]:has-[:focus]:text-sm',
+            '[&>*:last-child]:has-[:focus]:z-10',
 
             // Filled Input Label Appearance
             '[&>*:last-child]:has-[.filled]:-top-3',
-            '[&>*:last-child]:has-[.filled]:text-sm'
+            '[&>*:last-child]:has-[.filled]:text-sm',
+            '[&>*:last-child]:has-[.filled]:z-10'
         ]
     }
 };

--- a/presets/lara/floatlabel/index.js
+++ b/presets/lara/floatlabel/index.js
@@ -17,10 +17,12 @@ export default {
             // Focus Label Appearance
             '[&>*:last-child]:has-[:focus]:-top-3',
             '[&>*:last-child]:has-[:focus]:text-sm',
+            '[&>*:last-child]:has-[:focus]:z-10',
 
             // Filled Input Label Appearance
             '[&>*:last-child]:has-[.filled]:-top-3',
-            '[&>*:last-child]:has-[.filled]:text-sm'
+            '[&>*:last-child]:has-[.filled]:text-sm',
+            '[&>*:last-child]:has-[.filled]:z-10',
         ]
     }
 };


### PR DESCRIPTION
Multiple input components (`AutoComplete`, `CascadeSelect`, `DatePicker`, `InputMask`, `InputNumber`, `InputText`, `MultiSelect`, `TextArea` etc) set a `z-10` class, either by default or on focus. 

Setting the same `z-index` prevents the Floatlabel from transition from behind the input on focus.