### PR TITLE
fix: Lara Tooltip shadow 

### DIFF
--- a/presets/lara/tooltip/index.js
+++ b/presets/lara/tooltip/index.js
@@ -3,7 +3,6 @@ export default {
         class: [
             // Position and Shadows
             'absolute',
-            'shadow-md',
             'p-fadein',
             // Spacing
             {
@@ -45,6 +44,6 @@ export default {
         ]
     }),
     text: {
-        class: ['p-3', 'bg-surface-600 dark:bg-surface-600', 'text-white', 'leading-none', 'rounded-md', 'whitespace-pre-line', 'break-words']
+        class: ['p-3', 'bg-surface-600 dark:bg-surface-600', 'text-white', 'leading-none', 'rounded-md', 'shadow-md', 'whitespace-pre-line', 'break-words']
     }
 };


### PR DESCRIPTION
Shadow should be on "text" section and not on root which includes the arrow

![image](https://github.com/user-attachments/assets/89991091-bdc0-4974-a1c7-711ac0d553d8)

