### PR TITLE
bug: change pcInput to pcInputText

### DIFF
--- a/presets/aura/datepicker/index.js
+++ b/presets/aura/datepicker/index.js
@@ -10,7 +10,7 @@ export default {
             'relative'
         ]
     }),
-    pcInput: ({ props, parent }) => ({
+    pcInputText: ({ props, parent }) => ({
         root: {
             class: [
                 // Display

--- a/presets/aura/inputmask/index.js
+++ b/presets/aura/inputmask/index.js
@@ -1,5 +1,5 @@
 export default {
-    pcinputtext: {
+    pcInputText: {
         root: ({ context, props, parent }) => ({
             class: [
                 // Font

--- a/presets/aura/inputnumber/index.js
+++ b/presets/aura/inputnumber/index.js
@@ -17,7 +17,7 @@ export default {
             { '!w-16': props.showButtons && props.buttonLayout == 'vertical' }
         ]
     }),
-    pcInput: {
+    pcInputText: {
         root: ({ parent, context }) => ({
             class: [
                 // Font

--- a/presets/lara/datepicker/index.js
+++ b/presets/lara/datepicker/index.js
@@ -13,7 +13,7 @@ export default {
             { 'opacity-60 select-none pointer-events-none cursor-default': props.disabled }
         ]
     }),
-    pcInput: ({ props, parent }) => ({
+    pcInputText: ({ props, parent }) => ({
         root: {
             class: [
                 // Display

--- a/presets/lara/inputmask/index.js
+++ b/presets/lara/inputmask/index.js
@@ -1,5 +1,5 @@
 export default {
-    pcinputtext: {
+    pcInpuText: {
         root: ({ context, props, parent }) => ({
             class: [
                 // Font

--- a/presets/lara/inputnumber/index.js
+++ b/presets/lara/inputnumber/index.js
@@ -17,7 +17,7 @@ export default {
             { '!w-16': props.showButtons && props.buttonLayout == 'vertical' }
         ]
     }),
-    pcInput: {
+    pcInputText: {
         root: ({ parent, context }) => ({
             class: [
                 // Display


### PR DESCRIPTION
primevue 4.1.0 change `pcInput` to `pcInputText`
see https://github.com/primefaces/primevue/commit/5bc8f2a8e36354168bd0c14b5bda3462f4a7d04b

not shure if we also must change?
https://github.com/primefaces/primevue-tailwind/blob/main/presets/aura/inputotp/index.js#L7
https://github.com/primefaces/primevue-tailwind/blob/main/presets/lara/inputotp/index.js#L7
