### PR TITLE
Fix generating presets of components

### DIFF
--- a/assets/data/builder.json
+++ b/assets/data/builder.json
@@ -114,7 +114,13 @@
             "components": [
                 {
                     "name": "Button",
-                    "path": "button"
+                    "path": "button",
+                    "subComponents": [
+                        {
+                            "name": "ButtonGroup",
+                            "path": "buttongroup"
+                        }
+                    ]
                 },
                 {
                     "name": "Speed Dial",
@@ -172,7 +178,21 @@
             "components": [
                 {
                     "name": "Accordion",
-                    "path": "accordion"
+                    "path": "accordion",
+                    "subComponents": [
+                        {
+                            "name": "AccordionPanel",
+                            "path": "accordionpanel"
+                        },
+                        {
+                            "name": "AccordionHeader",
+                            "path": "accordionheader"
+                        },
+                        {
+                            "name": "AccordionContent",
+                            "path": "accordioncontent"
+                        }
+                    ]
                 },
                 {
                     "name": "Card",
@@ -200,15 +220,57 @@
                 },
                 {
                     "name": "Splitter",
-                    "path": "splitter"
+                    "path": "splitter",
+                    "subComponents": [
+                        {
+                            "name": "SplitterPanel",
+                            "path": "splitterpanel"
+                        }
+                    ]
                 },
                 {
                     "name": "Stepper",
-                    "path": "stepper"
+                    "path": "stepper",
+                    "subComponents": [
+                        {
+                            "name": "Step",
+                            "path": "step"
+                        },
+                        {
+                            "name": "StepList",
+                            "path": "steplist"
+                        },
+                        {
+                            "name": "StepPanels",
+                            "path": "steppanels"
+                        },
+                        {
+                            "name": "StepItem",
+                            "path": "stepitem"
+                        }
+                    ]
                 },
                 {
                     "name": "Tabs",
-                    "path": "tabs"
+                    "path": "tabs",
+                    "subComponents": [
+                        {
+                            "name": "Tab",
+                            "path": "tab"
+                        },
+                        {
+                            "name": "TabList",
+                            "path": "tablist"
+                        },
+                        {
+                            "name": "TabPanels",
+                            "path": "tabpanels"
+                        },
+                        {
+                            "name": "TabPanel",
+                            "path": "tabpanel"
+                        }
+                    ]
                 },
                 {
                     "name": "Toolbar",
@@ -330,11 +392,23 @@
             "components": [
                 {
                     "name": "Avatar",
-                    "path": "avatar"
+                    "path": "avatar",
+                    "subComponents": [
+                        {
+                            "name": "AvatarGroup",
+                            "path": "avatargroup"
+                        }
+                    ]
                 },
                 {
                     "name": "Badge",
-                    "path": "badge"
+                    "path": "badge",
+                    "subComponents": [
+                        {
+                            "name": "OverlayBadge",
+                            "path": "overlaybadge"
+                        }
+                    ]
                 },
                 {
                     "name": "BlockUI",

--- a/pages/builder/index.vue
+++ b/pages/builder/index.vue
@@ -68,10 +68,18 @@ export default {
     },
     methods: {
         async generate() {
+            const components = this.selectedComponents.flatMap((component) => {
+                const subComponents = Object.values(this.builderData)
+                    .find((category) => category.components.some((c) => c.path === component))
+                    ?.components.find((c) => c.path === component)?.subComponents || [];
+
+                return [component, ...subComponents.map((sub) => sub.path)];
+            });
+
             const blob = await $fetch(`/api/builder`, {
                 method: 'POST',
                 body: {
-                    components: this.selectedComponents,
+                    components: components,
                     preset: this.preset,
                     filename: this.filename
                 }


### PR DESCRIPTION
The generation of presets for some components is not functioning correctly, causing the components to break due to missing presets. I’m unsure if the naming aligns with the codebase conventions, but I have updated the builder data by adding sub-components. Additionally, the `generate` method now accounts for these sub-components and maps them to the `body` parameter.