### PR TITLE
fix: Keep checked state background when using filled variant

### DIFF
--- a/assets/styles/primevue/checkbox.css
+++ b/assets/styles/primevue/checkbox.css
@@ -49,7 +49,7 @@
     @apply border-red-400 dark:border-red-300
 }
 
-.p-checkbox.p-variant-filled .p-checkbox-box {
+.p-checkbox.p-variant-filled:not(.p-checkbox-checked) .p-checkbox-box {
     @apply bg-surface-50 dark:bg-surface-800
 }
 


### PR DESCRIPTION
### This fixes the checkbox checked state background being overridden when using the filled variant.

When using the filled variant of the checkbox, the checked background gets overridden by the `.variant-filled` background. To fix this, the `.variant-filled` background should only apply when the checkbox is not in a checked state.

```css
.p-checkbox.p-variant-filled:not(.p-checkbox-checked) .p-checkbox-box {
    @apply bg-surface-50 dark:bg-surface-800
}
```
