### PR TITLE
Replace deprecated tailwind classes

### DIFF
--- a/assets/styles/primevue/carousel.css
+++ b/assets/styles/primevue/carousel.css
@@ -26,7 +26,7 @@
 
 .p-carousel-prev-button,
 .p-carousel-next-button {
-    @apply self-center flex-shrink-0
+    @apply self-center shrink-0
 }
 
 .p-carousel-indicator-list {

--- a/assets/styles/primevue/cascadeselect.css
+++ b/assets/styles/primevue/cascadeselect.css
@@ -37,7 +37,7 @@
 
 .p-cascadeselect-label {
     @apply block whitespace-nowrap overflow-hidden flex-auto w-[1%]
-        py-2 px-3 overflow-ellipsis
+        py-2 px-3 text-ellipsis
         text-surface-700 dark:text-surface-0 bg-transparent border-none outline-none
 }
 

--- a/assets/styles/primevue/drawer.css
+++ b/assets/styles/primevue/drawer.css
@@ -17,7 +17,7 @@
 }
 
 .p-drawer-header {
-    @apply flex items-center justify-between flex-shrink-0 p-5
+    @apply flex items-center justify-between shrink-0 p-5
 }
 
 .p-drawer-footer {

--- a/assets/styles/primevue/fileupload.css
+++ b/assets/styles/primevue/fileupload.css
@@ -37,7 +37,7 @@
 }
 
 .p-fileupload-file-thumbnail {
-    @apply flex-shrink-0
+    @apply shrink-0
 }
 
 .p-fileupload-file-actions {

--- a/assets/styles/primevue/galleria.css
+++ b/assets/styles/primevue/galleria.css
@@ -62,11 +62,11 @@
 }
 
 .p-galleria-thumbnails {
-    @apply flex flex-col overflow-auto flex-shrink-0
+    @apply flex flex-col overflow-auto shrink-0
 }
 
 .p-galleria-thumbnail-nav-button {
-    @apply self-center flex-grow-0 flex-shrink-0 basis-auto justify-center items-center overflow-hidden relative
+    @apply self-center flex-grow-0 shrink-0 basis-auto justify-center items-center overflow-hidden relative
         my-0 mx-2 p-0 border-none select-none cursor-pointer w-8 h-8 rounded-md transition-colors duration-200 bg-transparent
         text-surface-600 hover:bg-surface-100 hover:text-surface-700
         dark:text-surface-400 dark:hover:bg-surface-800 dark:hover:text-surface-0

--- a/assets/styles/primevue/galleria.css
+++ b/assets/styles/primevue/galleria.css
@@ -66,7 +66,7 @@
 }
 
 .p-galleria-thumbnail-nav-button {
-    @apply self-center flex-grow-0 shrink-0 basis-auto justify-center items-center overflow-hidden relative
+    @apply self-center grow-0 shrink-0 basis-auto justify-center items-center overflow-hidden relative
         my-0 mx-2 p-0 border-none select-none cursor-pointer w-8 h-8 rounded-md transition-colors duration-200 bg-transparent
         text-surface-600 hover:bg-surface-100 hover:text-surface-700
         dark:text-surface-400 dark:hover:bg-surface-800 dark:hover:text-surface-0

--- a/assets/styles/primevue/inputnumber.css
+++ b/assets/styles/primevue/inputnumber.css
@@ -5,7 +5,7 @@
 }
 
 .p-inputnumber-button {
-    @apply flex items-center justify-center flex-grow-0 flex-shrink-0 basis-auto cursor-pointer w-10
+    @apply flex items-center justify-center flex-grow-0 shrink-0 basis-auto cursor-pointer w-10
         bg-transparent enabled:hover:bg-surface-100 enabled:active:bg-surface-200
         border border-surface-300 enabled:hover:border-surface-300 enabled:active:border-surface-300
         text-surface-400 enabled:hover:text-surface-500 enabled:active:text-surface-600

--- a/assets/styles/primevue/inputnumber.css
+++ b/assets/styles/primevue/inputnumber.css
@@ -5,7 +5,7 @@
 }
 
 .p-inputnumber-button {
-    @apply flex items-center justify-center flex-grow-0 shrink-0 basis-auto cursor-pointer w-10
+    @apply flex items-center justify-center grow-0 shrink-0 basis-auto cursor-pointer w-10
         bg-transparent enabled:hover:bg-surface-100 enabled:active:bg-surface-200
         border border-surface-300 enabled:hover:border-surface-300 enabled:active:border-surface-300
         text-surface-400 enabled:hover:text-surface-500 enabled:active:text-surface-600

--- a/assets/styles/primevue/megamenu.css
+++ b/assets/styles/primevue/megamenu.css
@@ -136,7 +136,7 @@
 .p-megamenu-col-4,
 .p-megamenu-col-6,
 .p-megamenu-col-12 {
-    @apply flex-grow-0 flex-shrink-0 basis-auto p-2
+    @apply flex-grow-0 shrink-0 basis-auto p-2
 }
 
 .p-megamenu-col-2 {

--- a/assets/styles/primevue/megamenu.css
+++ b/assets/styles/primevue/megamenu.css
@@ -136,7 +136,7 @@
 .p-megamenu-col-4,
 .p-megamenu-col-6,
 .p-megamenu-col-12 {
-    @apply flex-grow-0 shrink-0 basis-auto p-2
+    @apply grow-0 shrink-0 basis-auto p-2
 }
 
 .p-megamenu-col-2 {

--- a/assets/styles/primevue/message.css
+++ b/assets/styles/primevue/message.css
@@ -7,11 +7,11 @@
 }
 
 .p-message-icon {
-    @apply flex-shrink-0
+    @apply shrink-0
 }
 
 .p-message-close-button {
-    @apply flex items-center justify-center flex-shrink-0 ms-auto overflow-hidden relative cursor-pointer select-none
+    @apply flex items-center justify-center shrink-0 ms-auto overflow-hidden relative cursor-pointer select-none
         w-7 h-7 rounded-full bg-transparent transition-colors duration-200 text-inherit p-0 border-none
         focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2
 }

--- a/assets/styles/primevue/select.css
+++ b/assets/styles/primevue/select.css
@@ -41,7 +41,7 @@
 
 .p-select-label {
     @apply block whitespace-nowrap overflow-hidden flex-auto w-[1%]
-        py-2 px-3 overflow-ellipsis
+        py-2 px-3 text-ellipsis
         text-surface-700 dark:text-surface-0 bg-transparent border-none outline-none
 }
 

--- a/assets/styles/primevue/splitter.css
+++ b/assets/styles/primevue/splitter.css
@@ -10,11 +10,11 @@
 }
 
 .p-splitter-gutter {
-    @apply flex-grow-0 flex-shrink-0 flex items-center justify-center z-10 bg-surface-200 dark:bg-surface-700
+    @apply flex-grow-0 shrink-0 flex items-center justify-center z-10 bg-surface-200 dark:bg-surface-700
 }
 
 .p-splitter-gutter-handle {
-    @apply rounded-md bg-transparent 
+    @apply rounded-md bg-transparent
         focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
         transition-colors duration-200
 }

--- a/assets/styles/primevue/splitter.css
+++ b/assets/styles/primevue/splitter.css
@@ -10,7 +10,7 @@
 }
 
 .p-splitter-gutter {
-    @apply flex-grow-0 shrink-0 flex items-center justify-center z-10 bg-surface-200 dark:bg-surface-700
+    @apply grow-0 shrink-0 flex items-center justify-center z-10 bg-surface-200 dark:bg-surface-700
 }
 
 .p-splitter-gutter-handle {

--- a/assets/styles/primevue/stepper.css
+++ b/assets/styles/primevue/stepper.css
@@ -90,7 +90,7 @@
 }
 
 .p-stepitem .p-stepper-separator {
-    @apply flex-grow-0 flex-shrink-0 basis-auto w-[2px] h-auto ms-[1.625rem] relative start-[-2.5px]
+    @apply flex-grow-0 shrink-0 basis-auto w-[2px] h-auto ms-[1.625rem] relative start-[-2.5px]
 }
 
 .p-stepitem:has(~ .p-stepitem-active) .p-stepper-separator {

--- a/assets/styles/primevue/stepper.css
+++ b/assets/styles/primevue/stepper.css
@@ -90,7 +90,7 @@
 }
 
 .p-stepitem .p-stepper-separator {
-    @apply flex-grow-0 shrink-0 basis-auto w-[2px] h-auto ms-[1.625rem] relative start-[-2.5px]
+    @apply grow-0 shrink-0 basis-auto w-[2px] h-auto ms-[1.625rem] relative start-[-2.5px]
 }
 
 .p-stepitem:has(~ .p-stepitem-active) .p-stepper-separator {

--- a/assets/styles/primevue/tabs.css
+++ b/assets/styles/primevue/tabs.css
@@ -27,7 +27,7 @@
 }
 
 .p-tablist-nav-button {
-    @apply !absolute flex-shrink-0 top-0 z-20 h-full flex items-center justify-center cursor-pointer
+    @apply !absolute shrink-0 top-0 z-20 h-full flex items-center justify-center cursor-pointer
         bg-surface-0 dark:bg-surface-900 text-surface-500 dark:text-surface-400 hover:text-surface-700 dark:hover:text-surface-0 w-10
         shadow-[0px_0px_10px_50px_rgba(255,255,255,0.6)] dark:shadow-[0px_0px_10px_50px] dark:shadow-surface-900/50
         focus-visible:z-10 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-1px] focus-visible:outline-primary
@@ -48,7 +48,7 @@
 }
 
 .p-tab {
-    @apply flex-shrink-0 cursor-pointer select-none relative whitespace-nowrap py-4 px-[1.125rem]
+    @apply shrink-0 cursor-pointer select-none relative whitespace-nowrap py-4 px-[1.125rem]
         border-b border-surface-200 dark:border-surface-700 font-semibold
         text-surface-500 dark:text-surface-400
         transition-colors duration-200 -mb-px

--- a/assets/styles/primevue/toast.css
+++ b/assets/styles/primevue/toast.css
@@ -7,7 +7,7 @@
 }
 
 .p-toast-message-icon {
-    @apply flex-shrink-0 text-lg w-[1.125rem] h-[1.125rem]
+    @apply shrink-0 text-lg w-[1.125rem] h-[1.125rem]
 }
 
 .p-toast-message-content {

--- a/assets/styles/primevue/tree.css
+++ b/assets/styles/primevue/tree.css
@@ -44,7 +44,7 @@
 }
 
 .p-tree-node-toggle-button {
-    @apply cursor-pointer select-none inline-flex justify-center rounded-full items-center overflow-hidden relative flex-shrink-0
+    @apply cursor-pointer select-none inline-flex justify-center rounded-full items-center overflow-hidden relative shrink-0
         w-7 h-7 p-0 transition-colors duration-200 border-none
         bg-transparent enabled:hover:bg-surface-100 dark:enabled:hover:bg-surface-800
         text-surface-500 dark:text-surface-400 enabled:hover:text-surface-600 dark:enabled:hover:text-surface-300


### PR DESCRIPTION
See [Tailwind's upgrade guide from v3 to v4](https://tailwindcss.com/docs/upgrade-guide#removed-deprecated-utilities):

> We've removed any utilities that were deprecated in v3 and have been undocumented for several years.

This PR replaces those classes to make the migration to Tailwind v4 easier.