### PR TITLE
Remove duplicate selectors in radiobutton stylesheet

### DIFF
--- a/assets/styles/primevue/radiobutton.css
+++ b/assets/styles/primevue/radiobutton.css
@@ -17,12 +17,8 @@
 }
 
 .p-radiobutton-icon {
-    @apply bg-transparent text-xs w-3 h-3 rounded-full
-        transition-all duration-200 backface-hidden
-}
-
-.p-radiobutton-icon {
-    @apply scale-[0.1]
+    @apply h-3 w-3 scale-[0.1] rounded-full bg-transparent
+        text-xs transition-all duration-200 backface-hidden
 }
 
 .p-radiobutton:not(.p-disabled):has(.p-radiobutton-input:hover) .p-radiobutton-box {

--- a/assets/styles/primevue/radiobutton.css
+++ b/assets/styles/primevue/radiobutton.css
@@ -34,11 +34,7 @@
 }
 
 .p-radiobutton-checked .p-radiobutton-box .p-radiobutton-icon {
-    @apply bg-primary-contrast visible
-}
-
-.p-radiobutton-checked .p-radiobutton-box .p-radiobutton-icon {
-    @apply scale-100
+    @apply visible scale-100 bg-primary-contrast
 }
 
 .p-radiobutton-checked:not(.p-disabled):has(.p-radiobutton-input:hover) .p-radiobutton-box {


### PR DESCRIPTION
There are unnecessary duplicate selectors in the `radiobutton` stylesheet which will lead to an [no-duplicate-selectors](https://stylelint.io/user-guide/rules/no-duplicate-selectors/) stylelint error.